### PR TITLE
Navigation on All routes & Fixing CORS: Issue-6 PR

### DIFF
--- a/config.example.js
+++ b/config.example.js
@@ -1,3 +1,3 @@
-process.env.API_SERVER_URL = '127.0.0.1:8000';
-process.env.API_SERVER_DOMAIN = 'http://localhost:3001';
+process.env.API_SERVER_URL = 'http://127.0.0.1:3001';
+process.env.PROXY_TO_DOMAIN = 'http://localhost:3001';
 process.env.LIVE_SERVER_PORT = '8001';

--- a/config.example.js
+++ b/config.example.js
@@ -1,2 +1,3 @@
 process.env.API_SERVER_URL = '127.0.0.1:8000';
+process.env.API_SERVER_DOMAIN = 'http://localhost:3001';
 process.env.LIVE_SERVER_PORT = '8001';

--- a/package.json
+++ b/package.json
@@ -23,14 +23,15 @@
     "react-toastify": "^5.1.0",
     "style-loader": "^0.23.1",
     "styled-components": "^4.3.2",
-    "webpack": "^4.36.1"
+    "webpack": "^4.36.1",
+    "webpack-dev-server": "^3.8.1"
   },
   "devDependencies": {
     "webpack-cli": "^3.3.6"
   },
   "scripts": {
     "build": "webpack -d",
-    "start": "nodemon live-server",
+    "start": "webpack-dev-server --mode development",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {

--- a/src/event.edit/event.edit.jsx
+++ b/src/event.edit/event.edit.jsx
@@ -29,7 +29,7 @@ class EditEvent extends React.Component {
 			const { match: { params } } = this.props;
 			if (params._id) {
 				const eventId = params._id;
-				const response = await axios.get(`${process.env.API_SERVER_URL}/events/${eventId}`);
+				const response = await axios.get(`${process.env.API_SERVER_URL}/api/events/${eventId}`);
 				const event = response.data;
 				this.setState({
 					_id: event._id,
@@ -80,7 +80,7 @@ class EditEvent extends React.Component {
 			location: this.state.location
 		};
 		try {
-			await axios.post(`${process.env.API_SERVER_URL}/events`, {
+			await axios.post(`${process.env.API_SERVER_URL}/api/events`, {
 				event: event
 			});
 			const message = 'New Event Created Successfully!';
@@ -115,7 +115,7 @@ class EditEvent extends React.Component {
 		try {
 			await axios({
 				method: 'put',
-				url: `${process.env.API_SERVER_URL}/events/${event._id}`,
+				url: `${process.env.API_SERVER_URL}/api/events/${event._id}`,
 				data: {
 					event: event
 				}

--- a/src/react.big.calendar/calendar.jsx
+++ b/src/react.big.calendar/calendar.jsx
@@ -27,7 +27,7 @@ class CbsFullCalendar extends React.Component {
 
 	async componentDidMount() {
 		try {
-			let response = await axios.get(`${process.env.API_SERVER_URL}/events`);
+			let response = await axios.get(`${process.env.API_SERVER_URL}/api/events`);
 			response.data.events = response.data.events.map((event) => {
 				event.doc.start = moment.unix(event.doc.start).toDate();
 				event.doc.end = moment.unix(event.doc.end).toDate();

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,7 +22,7 @@ const config = {
     compress: true,
     port: process.env.LIVE_SERVER_PORT,
     historyApiFallback: true, // results in serving index.html for all non-matching routes
-    proxy: {
+    proxy: { // changes request origin from what it is to same as the target domain / server so CORS does not arise
       '/api': {
         target: process.env.PROXY_TO_DOMAIN
       }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,4 @@
+require('./config.js');
 const config = {
   entry: ['babel-polyfill', __dirname + '/src/app.jsx'],
   output: {
@@ -15,6 +16,12 @@ const config = {
       test:/\.css$/,
       use:['style-loader','css-loader']
     }]
+  },
+  devServer: {
+    contentBase: __dirname, // where the index.html must be present
+    compress: true,
+    port: process.env.LIVE_SERVER_PORT,
+    historyApiFallback: true // results in serving index.html for all non-matching routes
   }
 };
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,7 +24,7 @@ const config = {
     historyApiFallback: true, // results in serving index.html for all non-matching routes
     proxy: {
       '/api': {
-        target: process.env.API_SERVER_DOMAIN
+        target: process.env.PROXY_TO_DOMAIN
       }
     }
   }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,7 +21,12 @@ const config = {
     contentBase: __dirname, // where the index.html must be present
     compress: true,
     port: process.env.LIVE_SERVER_PORT,
-    historyApiFallback: true // results in serving index.html for all non-matching routes
+    historyApiFallback: true, // results in serving index.html for all non-matching routes
+    proxy: {
+      '/api': {
+        target: process.env.API_SERVER_DOMAIN
+      }
+    }
   }
 };
 


### PR DESCRIPTION
## Fixes #6 
## Solution
1. Introduced [webpack-dev-server](https://webpack.js.org/configuration/dev-server/)
2. Configured the dev server to serve `index.html` on all routes that do not match any correct file path on the dev server, hence loading the app via the html file.
3. Fooled the API server to treat requests from frontend (this repo) as if they are same origin requests by configuring `proxy` on webpack-dev-server`. After configuring the proxy, all requests made to the dev server are sent to the api server ip and in such a way that the latter considers them same origin requests.
4. Update urls to conform to changes to [backend](https://github.com/omeryousaf/alumni_network_api) APIs.